### PR TITLE
"ContentLength" has been recalculated for the updated body.

### DIFF
--- a/lib/networking/generic_request_object.dart
+++ b/lib/networking/generic_request_object.dart
@@ -204,6 +204,7 @@ class GenericRequestObject<ResponseType extends Serializable> {
             request.write(body);
           }
         } else if (body.isNotEmpty) {
+          request.headers.contentLength = utf8.encode(body).length;
           request.write(body);
         }
       }


### PR DESCRIPTION
Tekrar çağırılan sorgularda body değiştirilirse Header bilgisinde gönderilen contentLength boş gidiyordu. Bu durumlar için tekrar hesaplandı.